### PR TITLE
mongo collections, response parsing and kafka listener fixes

### DIFF
--- a/appointment-service/src/main/java/com/hungrycoders/model/Appointment.java
+++ b/appointment-service/src/main/java/com/hungrycoders/model/Appointment.java
@@ -10,6 +10,7 @@ import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.mapping.FieldType;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 /**
  * Represents an appointment entity with details about doctor, patient, and status.
@@ -23,7 +24,7 @@ public class Appointment {
 
     @Id
     @Field(targetType = FieldType.STRING)
-    private String id;
+    private UUID id;
 
     private Patient patient;
     private Doctor doctor;

--- a/appointment-service/src/main/java/com/hungrycoders/payload/response/GenericResponse.java
+++ b/appointment-service/src/main/java/com/hungrycoders/payload/response/GenericResponse.java
@@ -1,0 +1,20 @@
+package com.hungrycoders.payload.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GenericResponse<T> {
+    private String message;
+
+    private T data;
+
+    public GenericResponse(String message) {
+        this.message = message;
+    }
+}

--- a/appointment-service/src/main/java/com/hungrycoders/repository/AppointmentRepo.java
+++ b/appointment-service/src/main/java/com/hungrycoders/repository/AppointmentRepo.java
@@ -6,11 +6,12 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Repository interface for managing appointments in the database.
  */
-public interface AppointmentRepo extends MongoRepository<Appointment, String> {
+public interface AppointmentRepo extends MongoRepository<Appointment, UUID> {
 
     /**
      * Finds appointments by doctor ID, sorted as specified.

--- a/appointment-service/src/main/java/com/hungrycoders/service/AppointmentService.java
+++ b/appointment-service/src/main/java/com/hungrycoders/service/AppointmentService.java
@@ -8,15 +8,25 @@ import com.hungrycoders.model.AppointmentStatus;
 import com.hungrycoders.model.Doctor;
 import com.hungrycoders.model.Patient;
 import com.hungrycoders.payload.request.AppointmentRequest;
+import com.hungrycoders.payload.response.GenericResponse;
 import com.hungrycoders.repository.AppointmentRepo;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Service class to handle appointment-related business logic.
@@ -46,6 +56,7 @@ public class AppointmentService {
     @Value("${spring.kafka.producer.topic}")
     private String topicName;
 
+    private static final Logger logger = LoggerFactory.getLogger(AppointmentService.class);
     /**
      * Books a new appointment by validating doctor and patient information.
      *
@@ -54,14 +65,23 @@ public class AppointmentService {
      */
     public String bookAppointment(AppointmentRequest appointment) {
         try {
+
+            // Serialize Appointment object to JSON
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.registerModule(new JavaTimeModule());
+
             // Fetch and validate doctor details
             Doctor doctor = fetchDoctorDetails(appointment.getDoctorId().toString());
+            logger.info("Fetched doctor details inside book appointment: {}", objectMapper.writeValueAsString(doctor));
 
             // Fetch and validate patient details
             Patient patient = fetchPatientDetails(appointment.getPatientId().toString());
+            logger.info("Fetched patient details inside book appointment: {}", objectMapper.writeValueAsString(patient));
 
             // Create and save the appointment
+            UUID generatedId = UUID.randomUUID();
             Appointment newAppointment = new Appointment();
+            newAppointment.setId(generatedId);
             newAppointment.setDoctor(doctor);
             newAppointment.setPatient(patient);
             newAppointment.setAppointmentTime(appointment.getAppointmentTime());
@@ -69,14 +89,30 @@ public class AppointmentService {
             newAppointment.setNotes(appointment.getNotes());
             newAppointment.setStatus(AppointmentStatus.PENDING);
 
-            String appointmentId = appointmentRepository.save(newAppointment).getId();
+            String appointmentId = String.valueOf(appointmentRepository.save(newAppointment).getId());
 
-            // Serialize Appointment object to JSON
-            ObjectMapper objectMapper = new ObjectMapper();
-            objectMapper.registerModule(new JavaTimeModule());
+
             String appointmentJson = objectMapper.writeValueAsString(newAppointment);
             // send message to kafka
-            kafkaTemplate.send(topicName, appointmentJson);
+            // Send message to Kafka and handle the callback
+            // Send the message to Kafka and get a CompletableFuture
+            CompletableFuture<SendResult<String, String>> completableFuture = kafkaTemplate.send(topicName, appointmentJson);
+
+            // Add callbacks to handle success and failure
+            completableFuture.whenComplete((result, exception) -> {
+                if (exception == null) {
+                    // Success case
+                    RecordMetadata metadata = result.getRecordMetadata();
+                    logger.info("Message sent successfully to topic: {}", topicName);
+                    logger.info("Partition: {}, Offset: {}", metadata.partition(), metadata.offset());
+                } else {
+                    // Failure case
+                    logger.error("Failed to send message to topic: {}", topicName);
+                    logger.error(exception.getMessage());
+//                    exception.printStackTrace();
+                }
+            });
+
             return appointmentId;
         } catch (Exception e) {
             throw new ResourceNotFoundException("Error booking appointment: " + e.getMessage());
@@ -122,7 +158,7 @@ public class AppointmentService {
     public String updateAppointment(AppointmentRequest appointment) {
         try {
             // Find the existing appointment
-            Appointment existingAppointment = appointmentRepository.findById(appointment.getId())
+            Appointment existingAppointment = appointmentRepository.findById(UUID.fromString(appointment.getId()))
                     .orElseThrow(() -> new ResourceNotFoundException("Appointment not found with ID: " + appointment.getId()));
 
             // Fetch and validate doctor details
@@ -145,7 +181,7 @@ public class AppointmentService {
             existingAppointment.setDoctorComments(appointment.getDoctorComments());
             existingAppointment.setStatus(AppointmentStatus.fromValue(appointment.getStatus()));
 
-            return appointmentRepository.save(existingAppointment).getId();
+            return String.valueOf(appointmentRepository.save(existingAppointment).getId());
         } catch (Exception e) {
             throw new ResourceNotFoundException("Error updating appointment: " + e.getMessage());
         }
@@ -166,12 +202,21 @@ public class AppointmentService {
             );
         }
 
-        // Actual call in non-development environments
-        Doctor doctor = restTemplate.getForObject(doctorServiceUrl + "/" + doctorId, Doctor.class);
-        if (doctor == null) {
-            throw new ResourceNotFoundException("Doctor not found with ID: " + doctorId);
+        ResponseEntity<GenericResponse<Doctor>> responseEntity = restTemplate.exchange(
+                doctorServiceUrl + "/" + doctorId,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<GenericResponse<Doctor>>() {}
+        );
+
+        GenericResponse<Doctor> getDoctorResponse = responseEntity.getBody();
+
+        if (getDoctorResponse != null && getDoctorResponse.getData() != null) {
+            return getDoctorResponse.getData();
         }
-        return doctor;
+
+        throw new ResourceNotFoundException("Doctor not found with ID: " + doctorId);
+
     }
 
     private Patient fetchPatientDetails(String patientId) {
@@ -188,11 +233,20 @@ public class AppointmentService {
         }
 
         // Actual call in non-development environments
-        Patient patient = restTemplate.getForObject(patientServiceUrl + "/" + patientId, Patient.class);
-        if (patient == null) {
-            throw new ResourceNotFoundException("Patient not found with ID: " + patientId);
+        ResponseEntity<GenericResponse<Patient>> responseEntity = restTemplate.exchange(
+                patientServiceUrl + "/" + patientId,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<GenericResponse<Patient>>() {}
+        );
+
+        GenericResponse<Patient> getDoctorResponse = responseEntity.getBody();
+
+        if (getDoctorResponse != null && getDoctorResponse.getData() != null) {
+            return getDoctorResponse.getData();
         }
-        return patient;
+
+        throw new ResourceNotFoundException("Doctor not found with ID: " + patientId);
     }
 
     private boolean isDevelopmentEnvironment() {

--- a/notification-service/src/main/java/com/hungrycoders/config/KafkaConsumerConfig.java
+++ b/notification-service/src/main/java/com/hungrycoders/config/KafkaConsumerConfig.java
@@ -21,7 +21,7 @@ public class KafkaConsumerConfig {
 	@Value("${spring.kafka.bootstrap-servers}")
 	private String kafkaAddress;
 
-	@Value("${spring.kafka.group-id}")
+	@Value("${spring.kafka.consumer.group-id}")
 	private String groupId;
 
 	@Bean

--- a/notification-service/src/main/java/com/hungrycoders/listener/KafkaConsumerListener.java
+++ b/notification-service/src/main/java/com/hungrycoders/listener/KafkaConsumerListener.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.TopicPartition;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -20,7 +21,14 @@ public class KafkaConsumerListener {
 	@Autowired
 	private EmailService emailService;
 
-	@KafkaListener(topics = "${spring.kafka.topic.name}", groupId = "${spring.kafka.group-id}")
+//	@KafkaListener(
+//			topics = "${spring.kafka.topic.name}",
+//			groupId = "${spring.kafka.group-id}",
+//			partitions = "0")
+	@KafkaListener(
+			groupId = "${spring.kafka.consumer.group-id}",
+			topicPartitions = @TopicPartition(topic = "${spring.kafka.listener.topic}", partitions = "0")
+	)
 	public void listen(String message) throws JsonProcessingException {
 		// Deserialize the JSON message into an Appointment object
 		objectMapper.registerModule(new JavaTimeModule());

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -2,11 +2,15 @@ spring:
   application:
     name: notification-service
   kafka:
-    auto-offset-reset: latest
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVER}
-    group-id: ${KAFKA_GROUP_ID}
-    topic:
-      name: ${KAFKA_TOPIC}
+    bootstrap-servers: kafka:9092
+    consumer:
+      group-id: appointment-notifications-group
+      auto-offset-reset: latest
+      enable-auto-commit: false
+      properties:
+        "max.poll.interval.ms": 300000
+    listener:
+      topic: appointment-notifications
   mail:
     host: ${MAIL_SERVER_HOST}
     port: ${MAIL_SERVER_PORT}


### PR DESCRIPTION
Note: Issue with Kafka still persists.

Fixes in this PR:
1. Updated the appointment id type to UUID. 
2. Fixed the response handling for calls made to doctor and patient service from the appointment service.
3. Updated a few configurations related to kafka in the notification service.

Details about issues with kafka:
1. Once all the services are up using `docker-compose`, run this command from terminal to get into the kafka container: `docker exec -it kafka bash`
2. Run the same command in another terminal.
3. Now run these commands in both the terminals: `/opt/kafka/bin/kafka-console-producer.sh --bootstrap-server kafka:9092 --topic appointment-notifications` and in the other terminal run: `/opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic appointment-notifications --from-beginning --partition 0`
4. The issue is, it looks like we need to pass the `--partition 0` flag to consume the messages from kafka(refer: https://stackoverflow.com/questions/34844209/consumer-not-receiving-messages-kafka-console-new-consumer-api-kafka-0-9). Tried configuring that in the notification-service, but nothing worked. The message is getting sent succesfully to the topic from the appoint-service application but it is not getting consumed.